### PR TITLE
feat: add base.html layout template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}PathFinder{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+  {% block head %}{% endblock %}
+</head>
+<body class="bg-gray-50 text-gray-800">
+
+  <header class="bg-blue-600 text-white p-6 shadow">
+    <div class="container mx-auto flex justify-between items-center">
+      <h1 class="text-2xl font-bold">PathFinder</h1>
+      <nav>
+        <a href="{{ url_for('signup') }}" class="bg-white text-blue-600 px-4 py-2 rounded-xl shadow mr-2">Sign Up</a>
+        <a href="{{ url_for('login') }}" class="bg-blue-800 px-4 py-2 rounded-xl shadow">Log In</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="py-12 px-6 md:px-20">
+    {% block content %}{% endblock %}
+  </main>
+
+  <footer class="bg-gray-100 text-center text-sm text-gray-500 p-4 mt-10">
+    <p>&copy; 2025 PathFinder | <a href="#" class="underline">About</a> | <a href="#" class="underline">Contact</a> | <a href="#" class="underline">Privacy</a></p>
+  </footer>
+
+  {% block scripts %}{% endblock %}
+
+</body>
+</html>


### PR DESCRIPTION
This PR introduces `templates/base.html`, our shared layout:  
- Defines HTML head with blocks for title, head, and scripts.  
- Renders a consistent header (navbar) and footer.  
- Provides a `{% block content %}` for all page‑specific markup.  
