### PR TITLE
feat: add login.html user authentication template

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}Log In – PathFinder{% endblock %}
+
+{% block content %}
+<div class="max-w-md mx-auto bg-white p-8 rounded-2xl shadow">
+  <h2 class="text-3xl font-bold mb-6 text-center">Welcome Back</h2>
+  <form action="{{ url_for('login') }}" method="post" class="space-y-4">
+    <div>
+      <label for="username" class="block mb-1 font-medium">Username or Email</label>
+      <input type="text" name="username" id="username" required
+             class="w-full border-gray-300 rounded-lg p-2 focus:ring-2 focus:ring-blue-400" />
+    </div>
+    <div>
+      <label for="password" class="block mb-1 font-medium">Password</label>
+      <input type="password" name="password" id="password" required
+             class="w-full border-gray-300 rounded-lg p-2 focus:ring-2 focus:ring-blue-400" />
+    </div>
+    <button type="submit"
+            class="w-full bg-blue-600 text-white py-2 rounded-lg font-semibold hover:bg-blue-700 transition">
+      Log In
+    </button>
+  </form>
+  <p class="mt-6 text-center text-sm text-gray-600">
+    Don’t have an account?
+    <a href="{{ url_for('signup') }}" class="text-blue-600 hover:underline">Sign Up</a>
+  </p>
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR adds `templates/login.html` for user log‑in:  
- Extends `base.html`.  
- Displays a form with Username/Email and Password fields.  
- Includes link to Sign Up page.  
