### PR TITLE
feat: wire up /share route with stubbed entries and users

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from werkzeug.utils import secure_filename
 import os
 from flask import Flask, render_template, request, redirect, url_for, flash
 from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
 
 # Initialize Flask application
 application = Flask(__name__)
@@ -108,11 +109,20 @@ def visualize():
 
 @application.route('/share', methods=['GET', 'POST'])
 def share():
-    """Share Data view: allow user to share entries"""
+    # test data for demonstration purposes
+    entries = [
+        type('E', (), {'id': 1, 'filename': 'grades.csv', 'upload_date': datetime.today(), 'shared_with_ids': [2]}),
+        type('E', (), {'id': 2, 'filename': 'resume.pdf', 'upload_date': datetime.today(), 'shared_with_ids': []}),
+    ]
+    all_users = [
+        type('U', (), {'id': 1, 'username': 'alice'}),
+        type('U', (), {'id': 2, 'username': 'bob'}),
+        type('U', (), {'id': 3, 'username': 'carol'}),
+    ]
     if request.method == 'POST':
-        # TODO: handle share logic
-        return redirect(url_for('share'))
-    return render_template('share.html')
+        # handle form submission here…
+        pass
+    return render_template('share.html', entries=entries, all_users=all_users)
 
 @application.route('/dashboard')
 def dashboard():


### PR DESCRIPTION
This PR adds the backend support for the “Manage Sharing” page:
Introduces a new /share route (GET & POST) in app.py
On GET, renders share.html with stub data:
entries: a list of example uploads (id, filename, upload_date, shared_with_ids)
all_users: a list of example user objects (id, username)
On POST, accepts form submissions to update sharing (stubbed for now)
Imports datetime to populate each entry’s upload_date
Lays the groundwork for replacing stubs with real database queries and logic